### PR TITLE
refactor: Remove operator override on alertmanagerConfig top level co…

### DIFF
--- a/Documentation/api.md
+++ b/Documentation/api.md
@@ -19370,8 +19370,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Boolean indicating whether an alert should continue matching subsequent
-sibling nodes. It will always be overridden to true for the first-level
-route by the Prometheus operator.</p>
+sibling nodes.</p>
 </td>
 </tr>
 <tr>
@@ -23068,8 +23067,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>Boolean indicating whether an alert should continue matching subsequent
-sibling nodes. It will always be overridden to true for the first-level
-route by the Prometheus operator.</p>
+sibling nodes.</p>
 </td>
 </tr>
 <tr>

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4796,8 +4796,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd-full/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4819,8 +4819,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated
@@ -9533,8 +9532,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+++ b/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
@@ -4796,8 +4796,7 @@ spec:
                     type: array
                   continue:
                     description: Boolean indicating whether an alert should continue
-                      matching subsequent sibling nodes. It will always be overridden
-                      to true for the first-level route by the Prometheus operator.
+                      matching subsequent sibling nodes.
                     type: boolean
                   groupBy:
                     description: List of labels to group by. Labels must not be repeated

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-crd.json
@@ -5010,7 +5010,7 @@
                         "type": "array"
                       },
                       "continue": {
-                        "description": "Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.",
+                        "description": "Boolean indicating whether an alert should continue matching subsequent sibling nodes.",
                         "type": "boolean"
                       },
                       "groupBy": {

--- a/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
+++ b/jsonnet/prometheus-operator/alertmanagerconfigs-v1beta1-crd.libsonnet
@@ -4857,7 +4857,7 @@
                     type: 'array',
                   },
                   continue: {
-                    description: 'Boolean indicating whether an alert should continue matching subsequent sibling nodes. It will always be overridden to true for the first-level route by the Prometheus operator.',
+                    description: 'Boolean indicating whether an alert should continue matching subsequent sibling nodes.',
                     type: 'boolean',
                   },
                   groupBy: {

--- a/pkg/alertmanager/amcfg.go
+++ b/pkg/alertmanager/amcfg.go
@@ -118,7 +118,6 @@ func (ne *noopEnforcer) processInhibitRule(_ types.NamespacedName, ir *inhibitRu
 }
 
 func (ne *noopEnforcer) processRoute(_ types.NamespacedName, r *route) *route {
-	r.Continue = true
 	return r
 }
 
@@ -175,8 +174,6 @@ func (ne *namespaceEnforcer) processRoute(crKey types.NamespacedName, r *route) 
 	} else {
 		r.Match["namespace"] = crKey.Namespace
 	}
-	// Alerts should still be evaluated by the following routes.
-	r.Continue = true
 
 	return r
 }

--- a/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1alpha1/alertmanager_config_types.go
@@ -115,8 +115,7 @@ type Route struct {
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// Boolean indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be overridden to true for the first-level
-	// route by the Prometheus operator.
+	// sibling nodes.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.

--- a/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
+++ b/pkg/apis/monitoring/v1beta1/alertmanager_config_types.go
@@ -114,8 +114,7 @@ type Route struct {
 	// +optional
 	Matchers []Matcher `json:"matchers,omitempty"`
 	// Boolean indicating whether an alert should continue matching subsequent
-	// sibling nodes. It will always be overridden to true for the first-level
-	// route by the Prometheus operator.
+	// sibling nodes.
 	// +optional
 	Continue bool `json:"continue,omitempty"`
 	// Child routes.


### PR DESCRIPTION
…ntinue

Allow user to decide if they want the alert to still be evaluated by the following routes or not. Having the override blocks the possible usage where you have a catch all route generating duplicate alerts since the route added by an alertmanagerConfig already filter to its namespace.

Fixes #5019

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the Prometheus operator? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
